### PR TITLE
Add `@meta` and `@metas` directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,42 @@ class HomeController extends Controller
 </html>
 ```
 
+Or you can use Blade directives:
+
+```php
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="author" content="Lito - lito@eordes.com" />
+
+        <title>{!! Meta::get('title') !!}</title>
+
+        @meta('robots')
+
+        @meta('site_name', 'My site')
+        @meta('url', Request::url())
+        @meta('locale', 'en_EN')
+
+        @meta('title')
+        @meta('description')
+
+        {{-- Print custom section images and a default image after that --}}
+        @meta('image', asset('images/default-logo.png'))
+
+        {{-- Or use @metas to get all tags at once --}}
+        @metas
+        
+    </head>
+
+    <body>
+        ...
+    </body>
+</html>
+```
+
 ### Config
 
 ```php

--- a/src/Eusonlito/LaravelMeta/MetaServiceProvider.php
+++ b/src/Eusonlito/LaravelMeta/MetaServiceProvider.php
@@ -2,6 +2,7 @@
 namespace Eusonlito\LaravelMeta;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\View\Compilers\BladeCompiler;
 
 class MetaServiceProvider extends ServiceProvider
 {
@@ -22,6 +23,8 @@ class MetaServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../../config/config.php' => config_path('meta.php')
         ]);
+
+        $this->addBladeDirectives();
     }
 
     /**
@@ -44,5 +47,23 @@ class MetaServiceProvider extends ServiceProvider
     public function provides()
     {
         return ['meta'];
+    }
+
+    /**
+     * Register blade directives
+     *
+     * @return void
+     */
+    protected function addBladeDirectives()
+    {
+        $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
+            $bladeCompiler->directive('meta', function ($arguments) {
+                return "<?php echo Meta::tag($arguments); ?>";
+            });
+
+            $bladeCompiler->directive('metas', function ($arguments) {
+                return "<?php echo Meta::tags($arguments); ?>";
+            });
+        });
     }
 }


### PR DESCRIPTION
This PR add two blade directives to use in templates
- `@meta` which is a shortcut for `Meta::tag`
- `@metas` which is a shortcut for `Meta::tags`