### PR TITLE
Add meta (link) canonical support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ class HomeController extends Controller
         # Add only this last image
         Meta::set('image', asset('images/detail-logo.png'));
 
+        # Canonical URL
+        Meta::set('canonical', 'http://example.com');
+
         return view('detail');
     }
 
@@ -146,6 +149,8 @@ class HomeController extends Controller
         {!! Meta::tag('title') !!}
         {!! Meta::tag('description') !!}
 
+        {!! Meta::tag('canonical') !!}
+
         {{-- Print custom section images and a default image after that --}}
         {!! Meta::tag('image', asset('images/default-logo.png')) !!}
     </head>
@@ -177,6 +182,8 @@ Or you can use Blade directives:
 
         @meta('title')
         @meta('description')
+
+        @meta('canonical')
 
         {{-- Print custom section images and a default image after that --}}
         @meta('image', asset('images/default-logo.png'))
@@ -264,6 +271,9 @@ $Meta->set('robots', 'index,follow');
 $Meta->set('title', 'This is a detail page');
 $Meta->set('description', 'All about this detail page');
 $Meta->set('image', '/images/detail-logo.png');
+
+# Canonical URL
+$Meta->set('canonical', 'http://example.com');
 ```
 
 #### Template
@@ -279,6 +289,8 @@ $Meta->set('image', '/images/detail-logo.png');
 
 <?= $Meta->tag('title'); ?>
 <?= $Meta->tag('description'); ?>
+
+<?= $Meta->tag('canonical'); ?>
 
 # Print custom section image and a default image after that
 <?= $Meta->tag('image', '/images/default-logo.png'); ?>

--- a/src/Eusonlito/LaravelMeta/Tags/MetaName.php
+++ b/src/Eusonlito/LaravelMeta/Tags/MetaName.php
@@ -3,8 +3,12 @@ namespace Eusonlito\LaravelMeta\Tags;
 
 class MetaName extends TagAbstract
 {
+    protected static $specials = ['canonical'];
+
     public static function tagDefault($key, $value)
     {
-        return '<meta name="'.$key.'" content="'.$value.'" />';
+        if (!in_array($key, self::$specials, true)) {
+            return '<meta name="'.$key.'" content="'.$value.'" />';
+        }
     }
 }

--- a/src/Eusonlito/LaravelMeta/Tags/Tag.php
+++ b/src/Eusonlito/LaravelMeta/Tags/Tag.php
@@ -3,7 +3,7 @@ namespace Eusonlito\LaravelMeta\Tags;
 
 class Tag extends TagAbstract
 {
-    protected static $custom = ['image'];
+    protected static $custom = ['image', 'canonical'];
     protected static $available = ['title'];
 
     public static function tagDefault($key, $value)
@@ -16,5 +16,10 @@ class Tag extends TagAbstract
     public static function tagImage($key, $value)
     {
         return '<link rel="image_src" href="'.$value.'" />';
+    }
+
+    public static function tagCanonical($key, $value)
+    {
+        return '<link rel="canonical" href="'.$value.'" />';
     }
 }


### PR DESCRIPTION
Soporte para añadir el meta canonical que sólo debe ir en formato <link rel="canonical" ... y no generar otros tags no nocesarios